### PR TITLE
Add Yekta Academy theme with courses and lessons

### DIFF
--- a/archive-course.php
+++ b/archive-course.php
@@ -1,0 +1,11 @@
+<?php get_header(); ?>
+<h2><?php post_type_archive_title(); ?></h2>
+<?php if (have_posts()): while (have_posts()): the_post(); ?>
+<article>
+    <h3><a href="<?php the_permalink(); ?>"><?php the_title(); ?></a></h3>
+    <?php the_excerpt(); ?>
+</article>
+<?php endwhile; else: ?>
+<p><?php _e('No courses found.', 'yektatheme'); ?></p>
+<?php endif; ?>
+<?php get_footer(); ?>

--- a/footer.php
+++ b/footer.php
@@ -1,0 +1,7 @@
+</main>
+<footer>
+    <p>&copy; <?php echo date('Y'); ?> Yekta Academy</p>
+</footer>
+<?php wp_footer(); ?>
+</body>
+</html>

--- a/front-page.php
+++ b/front-page.php
@@ -1,0 +1,7 @@
+<?php get_header(); ?>
+<?php while (have_posts()): the_post(); ?>
+<div class="home-content">
+    <?php the_content(); ?>
+</div>
+<?php endwhile; ?>
+<?php get_footer(); ?>

--- a/functions.php
+++ b/functions.php
@@ -1,0 +1,36 @@
+<?php
+function yektatheme_setup() {
+    add_theme_support('title-tag');
+    add_theme_support('post-thumbnails');
+    register_nav_menus(array(
+        'primary' => __('Primary Menu', 'yektatheme')
+    ));
+}
+add_action('after_setup_theme', 'yektatheme_setup');
+
+function yektatheme_register_post_types() {
+    register_post_type('course', array(
+        'labels' => array(
+            'name' => __('Courses', 'yektatheme'),
+            'singular_name' => __('Course', 'yektatheme')
+        ),
+        'public' => true,
+        'has_archive' => true,
+        'show_in_rest' => true,
+        'supports' => array('title', 'editor', 'thumbnail', 'excerpt'),
+        'rewrite' => array('slug' => 'courses')
+    ));
+
+    register_post_type('lesson', array(
+        'labels' => array(
+            'name' => __('Lessons', 'yektatheme'),
+            'singular_name' => __('Lesson', 'yektatheme')
+        ),
+        'public' => true,
+        'has_archive' => false,
+        'show_in_rest' => true,
+        'supports' => array('title', 'editor', 'thumbnail', 'excerpt'),
+        'rewrite' => array('slug' => 'lessons')
+    ));
+}
+add_action('init', 'yektatheme_register_post_types');

--- a/header.php
+++ b/header.php
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<html <?php language_attributes(); ?>>
+<head>
+    <meta charset="<?php bloginfo('charset'); ?>">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <?php wp_head(); ?>
+</head>
+<body <?php body_class(); ?>>
+<header>
+    <h1><a href="<?php echo esc_url(home_url('/')); ?>"><?php bloginfo('name'); ?></a></h1>
+    <?php wp_nav_menu(array('theme_location' => 'primary')); ?>
+</header>
+<main>

--- a/index.php
+++ b/index.php
@@ -1,0 +1,10 @@
+<?php get_header(); ?>
+<?php if (have_posts()): while (have_posts()): the_post(); ?>
+<article>
+    <h2><a href="<?php the_permalink(); ?>"><?php the_title(); ?></a></h2>
+    <?php the_excerpt(); ?>
+</article>
+<?php endwhile; else: ?>
+<p><?php _e('No content found.', 'yektatheme'); ?></p>
+<?php endif; ?>
+<?php get_footer(); ?>

--- a/page-about.php
+++ b/page-about.php
@@ -1,0 +1,8 @@
+<?php get_header(); ?>
+<?php while (have_posts()): the_post(); ?>
+<article>
+    <h2><?php the_title(); ?></h2>
+    <?php the_content(); ?>
+</article>
+<?php endwhile; ?>
+<?php get_footer(); ?>

--- a/page-contact.php
+++ b/page-contact.php
@@ -1,0 +1,8 @@
+<?php get_header(); ?>
+<?php while (have_posts()): the_post(); ?>
+<article>
+    <h2><?php the_title(); ?></h2>
+    <?php the_content(); ?>
+</article>
+<?php endwhile; ?>
+<?php get_footer(); ?>

--- a/single-course.php
+++ b/single-course.php
@@ -1,0 +1,8 @@
+<?php get_header(); ?>
+<?php if (have_posts()): while (have_posts()): the_post(); ?>
+<article>
+    <h2><?php the_title(); ?></h2>
+    <?php the_content(); ?>
+</article>
+<?php endwhile; endif; ?>
+<?php get_footer(); ?>

--- a/single-lesson.php
+++ b/single-lesson.php
@@ -1,0 +1,8 @@
+<?php get_header(); ?>
+<?php if (have_posts()): while (have_posts()): the_post(); ?>
+<article>
+    <h2><?php the_title(); ?></h2>
+    <?php the_content(); ?>
+</article>
+<?php endwhile; endif; ?>
+<?php get_footer(); ?>

--- a/style.css
+++ b/style.css
@@ -1,1 +1,28 @@
-/* -- */
+/*
+Theme Name: Yekta Academy
+Theme URI: https://example.com/yalms
+Author: Yekta Academy
+Author URI: https://example.com
+Description: Custom theme for Yekta Academy with Course and Lesson post types.
+Version: 1.0.0
+License: GPLv2 or later
+License URI: https://www.gnu.org/licenses/gpl-2.0.html
+Text Domain: yektatheme
+GitHub Theme URI: https://github.com/YektaAcademy/yalms
+Primary Branch: main
+Update URI: https://github.com/YektaAcademy/yalms
+*/
+
+body {
+    margin: 0;
+    font-family: Arial, sans-serif;
+}
+
+header, footer {
+    background: #f2f2f2;
+    padding: 1rem;
+}
+
+main {
+    padding: 1rem;
+}


### PR DESCRIPTION
## Summary
- build Yekta Academy theme with custom Course and Lesson post types
- add templates for home, pages, course archive, and single course/lesson
- include metadata for updating theme from GitHub

## Testing
- `find . -name '*.php' -print0 | xargs -0 -n1 php -l`


------
https://chatgpt.com/codex/tasks/task_e_68c1695496e48321933ca8571573422d